### PR TITLE
Move interactive demos to examples

### DIFF
--- a/examples/stock_data_demo.py
+++ b/examples/stock_data_demo.py
@@ -1,0 +1,4 @@
+from stock.stock_data import main
+
+if __name__ == "__main__":
+    main()

--- a/examples/stock_news_demo.py
+++ b/examples/stock_news_demo.py
@@ -1,0 +1,4 @@
+from stock.stock_news import main
+
+if __name__ == "__main__":
+    main()

--- a/examples/stock_symbol_demo.py
+++ b/examples/stock_symbol_demo.py
@@ -1,0 +1,4 @@
+from stock.stock_symbol import main
+
+if __name__ == "__main__":
+    main()

--- a/stock/stock_data.py
+++ b/stock/stock_data.py
@@ -365,29 +365,3 @@ def main():
         pe = f"{data['P/E']:.1f}" if isinstance(data['P/E'], (int, float)) else str(data['P/E'])
         print(f"{symbol:<10}{price:<12}{rsi:<10}{pe:<10}")
 
-if __name__ == "__main__":
-    # Required installations (run these in terminal):
-    print("Required packages: pip install yfinance pandas numpy requests")
-    print("=" * 60)
-
-    # Get stock symbol from user input
-    company_name = input("Enter company name (or press Enter for 'Apple'): ").strip()
-    symbol = quick_symbol_lookup(company_name)
-    print(symbol)
-    
-    #main()
-    # Create analyzer instance
-    if symbol is None:
-        print(f"No valid stock symbol found. Using default {company_name}")
-    else:
-        analyzer = StockAnalyzer(symbol)    
-        # Generate comprehensive report
-        analysis_results = analyzer.generate_report()
-        # Get news articles
-        news = get_news(symbol, analysis_results['basic_info']['Company Name'])
-        print("\nNews articles fetched successfully.")
-        print(f"\n{'='*60}")
-        print(news)
-    # Print analysis results
-
-    

--- a/stock/stock_news.py
+++ b/stock/stock_news.py
@@ -621,10 +621,3 @@ def main():
     #     print(f"  Latest: {data['latest_headline'][:80]}...")
     #     print(f"  Sentiment: {data['sentiment']}")
 
-if __name__ == "__main__":
-    print("Stock News Extractor")
-    print("Required packages: pip install yfinance requests pandas beautifulsoup4 feedparser")
-    print("Optional: NewsAPI key from newsapi.org, Alpha Vantage key from alphavantage.co")
-    print("=" * 70)
-    
-    main()

--- a/stock/stock_symbol.py
+++ b/stock/stock_symbol.py
@@ -511,18 +511,3 @@ def validate_symbol(symbol: str) -> Dict:
     
     return {'valid': False}
 
-if __name__ == "__main__":
-    # Required installations
-    print("Required packages: pip install yfinance requests pandas fuzzywuzzy python-Levenshtein")
-    print("=" * 80)
-    
-    #main()
-    company_name = "Tata Motors"
-    # Initialize the finder
-    # finder = StockSymbolFinder()
-    # results = finder.find_symbol(company_name)
-    # finder.display_results(results)
-    print(quick_symbol_lookup(company_name))
-
-# Additional utility functions
-


### PR DESCRIPTION
## Summary
- remove embedded demo logic from core stock modules
- add demo scripts under `examples` for stock data, news, and symbol lookup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68640b4b72dc83278e94eb8254763909