### PR TITLE
Add unit tests for stock agent modules

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) )

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,52 @@
+import asyncio
+from types import SimpleNamespace
+import agent.fundamental_agent as fa
+import agent.technical_agent as ta
+import agent.investment_agent as ia
+import agent.news_agent as na
+import agent.stock_manager_agent as sm
+
+
+def test_fundamental_agent(monkeypatch):
+    async def dummy_run(agent, items):
+        return 'ok'
+    monkeypatch.setattr(fa.Runner, 'run', dummy_run)
+    result = SimpleNamespace(final_output=SimpleNamespace(fundamental_data={}))
+    assert asyncio.run(fa.fundamental_agent(result)) == 'ok'
+
+
+def test_technical_agent(monkeypatch):
+    async def dummy_run(agent, items):
+        return 'ok'
+    monkeypatch.setattr(ta.Runner, 'run', dummy_run)
+    result = SimpleNamespace(final_output=SimpleNamespace(technical_data={}))
+    assert asyncio.run(ta.technical_agent(result)) == 'ok'
+
+
+def test_news_agent(monkeypatch):
+    async def dummy_run(agent, items):
+        return 'ok'
+    monkeypatch.setattr(na.Runner, 'run', dummy_run)
+    result = SimpleNamespace(final_output=SimpleNamespace(news=[]))
+    assert asyncio.run(na.news_agent(result)) == 'ok'
+
+
+def test_investment_agent(monkeypatch):
+    async def dummy_run(agent, items):
+        return 'ok'
+    monkeypatch.setattr(ia.Runner, 'run', dummy_run)
+    out = asyncio.run(ia.investment_agent({}, {}, {}, {}))
+    assert out == 'ok'
+
+
+def test_supervisor_final_report(monkeypatch):
+    manager = sm.SupervisorManager()
+    manager.table_report = SimpleNamespace(final_output='table')
+    manager.technical_result = SimpleNamespace(final_output='tech')
+    manager.fundamental_result = SimpleNamespace(final_output='fund')
+    manager.news_result = SimpleNamespace(final_output='news')
+    manager.investment_result = SimpleNamespace(final_output='inv')
+
+    monkeypatch.setattr(sm, 'AgentOutputSchema', SimpleNamespace)
+    result = asyncio.run(manager.final_report())
+    assert result == 'table\n\ntech\n\nfund\n\nnews\n\ninv\n\n'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,21 @@
+import ast
+import types
+from pathlib import Path
+
+
+def load_function():
+    source = Path('main.py').read_text()
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == 'markdown_to_pdf_bytes':
+            mod = ast.Module(body=[node], type_ignores=[])
+            ns = {}
+            exec(compile(mod, '<main>', 'exec'), ns)
+            return ns['markdown_to_pdf_bytes']
+    raise RuntimeError('function not found')
+
+
+def test_markdown_to_pdf_bytes():
+    func = load_function()
+    data = func('# Title')
+    assert data.startswith(b'%PDF')

--- a/tests/test_stock_data.py
+++ b/tests/test_stock_data.py
@@ -1,0 +1,47 @@
+import pandas as pd
+import pytest
+from stock.stock_data import StockAnalyzer, get_alpha_vantage_data
+
+class DummyTicker:
+    info = {}
+    financials = pd.DataFrame()
+    balance_sheet = pd.DataFrame()
+    cashflow = pd.DataFrame()
+    recommendations = pd.DataFrame()
+    def history(self, *args, **kwargs):
+        return pd.DataFrame()
+
+
+def test_calculate_technical_indicators_empty(monkeypatch):
+    monkeypatch.setattr('yfinance.Ticker', lambda symbol: DummyTicker())
+    analyzer = StockAnalyzer('TEST')
+    result = analyzer.calculate_technical_indicators()
+    assert result == {}
+
+
+def test_analyze_stock_signals(monkeypatch):
+    monkeypatch.setattr('yfinance.Ticker', lambda symbol: DummyTicker())
+    analyzer = StockAnalyzer('TEST')
+    technical = {
+        'Current Price': 120,
+        'SMA 20': 110,
+        'SMA 50': 100,
+        'RSI': 80,
+        'MACD': 1,
+        'MACD Signal': 0.5,
+    }
+    signals = analyzer.analyze_stock_signals(technical)
+    assert any('RSI Overbought' in s for s in signals)
+    assert any('Price above both SMA 20 and 50' in s for s in signals)
+    assert any('MACD above Signal Line' in s for s in signals)
+
+
+def test_get_alpha_vantage_data(monkeypatch):
+    class DummyResponse:
+        def __init__(self, json_data):
+            self._json = json_data
+        def json(self):
+            return self._json
+    monkeypatch.setattr('requests.get', lambda url: DummyResponse({'MarketCapitalization': '1000'}))
+    data = get_alpha_vantage_data('TEST', 'key')
+    assert data['Market Cap'] == '1000'

--- a/tests/test_stock_news.py
+++ b/tests/test_stock_news.py
@@ -1,0 +1,21 @@
+import pandas as pd
+from stock.stock_news import StockNewsExtractor
+
+
+def test_analyze_sentiment_positive():
+    extractor = StockNewsExtractor()
+    result = extractor.analyze_sentiment('Strong buy recommendation with profit')
+    assert result['sentiment'] == 'Positive'
+
+
+def test_get_news_summary():
+    extractor = StockNewsExtractor()
+    df = pd.DataFrame({
+        'source': ['Yahoo', 'Yahoo', 'Finviz'],
+        'extraction_method': ['Yahoo', 'Yahoo', 'Finviz'],
+        'sentiment': ['Positive', 'Negative', 'Positive'],
+        'published': ['2024-01-01', '2024-01-02', '2024-01-03'],
+    })
+    summary = extractor.get_news_summary(df)
+    assert summary['total_articles'] == 3
+    assert summary['sources']['Yahoo'] == 2

--- a/tests/test_stock_symbol.py
+++ b/tests/test_stock_symbol.py
@@ -1,0 +1,35 @@
+import pandas as pd
+import pytest
+from stock.stock_symbol import StockSymbolFinder, validate_symbol
+
+class DummyTicker:
+    def __init__(self, valid=True):
+        self.valid = valid
+        self.info = {'longName':'Apple Inc','sector':'Tech','industry':'SW','exchange':'NAS'} if valid else {}
+
+
+def test_generate_potential_symbols_single_word():
+    finder = StockSymbolFinder()
+    symbols = finder._generate_potential_symbols('Apple')
+    assert 'APPL' in symbols
+
+
+def test_is_name_match():
+    finder = StockSymbolFinder()
+    assert finder._is_name_match('Apple Inc', 'Apple Inc.')
+
+
+def test_deduplicate_results():
+    finder = StockSymbolFinder()
+    results = [{'symbol':'AAPL','name':'A'}, {'symbol':'AAPL','name':'B'}, {'symbol':'MSFT','name':'C'}]
+    unique = finder._deduplicate_results(results)
+    assert len(unique) == 2
+
+
+def test_validate_symbol(monkeypatch):
+    monkeypatch.setattr('yfinance.Ticker', lambda sym: DummyTicker(True))
+    data = validate_symbol('AAPL')
+    assert data['valid']
+    monkeypatch.setattr('yfinance.Ticker', lambda sym: DummyTicker(False))
+    data = validate_symbol('XXXX')
+    assert not data['valid']


### PR DESCRIPTION
## Summary
- create test suite covering key functionality in core modules
- verify technical signal analysis logic
- check sentiment and news summary utilities
- validate symbol helpers and main PDF output
- add async agent tests and supervisor report check

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68641483b5e08327bc4ff23b9239ca9a