### PR TITLE
Fix cross-platform temp PDF path

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import gradio as gr
 from dotenv import load_dotenv
 from pathlib import Path
+import tempfile
 
 from agent.stock_manager_agent import SupervisorManager
 
@@ -60,7 +61,8 @@ async def run(query: str):
         yield chunk, None
 
     pdf_bytes = markdown_to_pdf_bytes(last_chunk)
-    pdf_path = Path("/tmp/report.pdf")
+    temp_dir = Path(tempfile.gettempdir())
+    pdf_path = temp_dir / "report.pdf"
     pdf_path.write_bytes(pdf_bytes)
     yield last_chunk, str(pdf_path)
 


### PR DESCRIPTION
## Summary
- handle PDF path creation in a cross-platform manner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686415f7c3848327841fb4ffc09dee9c