### PR TITLE
Add PDF download button

### DIFF
--- a/app/agent/stock_manager_agent.py
+++ b/app/agent/stock_manager_agent.py
@@ -1,9 +1,16 @@
-from agents import Agent, Runner, trace, gen_trace_id, TResponseInputItem, AgentOutputSchema
-from agent.technical_agent import technical_agent
-from agent.fundamental_agent import fundamental_agent
-from agent.investment_agent import investment_agent
-from agent.news_agent import news_agent
-from agent.stock_query_agent import query_agent
+from agents import (
+    Agent,
+    Runner,
+    trace,
+    gen_trace_id,
+    TResponseInputItem,
+    AgentOutputSchema,
+)
+from .technical_agent import technical_agent
+from .fundamental_agent import fundamental_agent
+from .investment_agent import investment_agent
+from .news_agent import news_agent
+from .stock_query_agent import query_agent
 
 REPORT_INSTRUCTION = """
             You need create tabular report based on the stock data of technical, fundamental, trend signal and stock news.

--- a/app/agent/stock_query_agent.py
+++ b/app/agent/stock_query_agent.py
@@ -1,7 +1,7 @@
 from agents import Agent, Runner, function_tool, AgentOutputSchema
 from pydantic import BaseModel
 from typing import Set, List, Dict, Tuple
-from stock.stock_data import StockAnalyzer, quick_symbol_lookup, get_news
+from ..stock.stock_data import StockAnalyzer, quick_symbol_lookup, get_news
 
 @function_tool
 def stock_analysis_tool(company_name: str, symbol: str = None) -> Dict[str, str]:

--- a/app/examples/stock_data_demo.py
+++ b/app/examples/stock_data_demo.py
@@ -1,4 +1,4 @@
-from stock.stock_data import main
+from ..stock.stock_data import main
 
 if __name__ == "__main__":
     main()

--- a/app/examples/stock_news_demo.py
+++ b/app/examples/stock_news_demo.py
@@ -1,4 +1,4 @@
-from stock.stock_news import main
+from ..stock.stock_news import main
 
 if __name__ == "__main__":
     main()

--- a/app/examples/stock_symbol_demo.py
+++ b/app/examples/stock_symbol_demo.py
@@ -1,4 +1,4 @@
-from stock.stock_symbol import main
+from ..stock.stock_symbol import main
 
 if __name__ == "__main__":
     main()

--- a/app/main.py
+++ b/app/main.py
@@ -74,7 +74,7 @@ def save_pdf(report_text: str):
     temp_dir = Path(tempfile.gettempdir())
     pdf_path = temp_dir / "report.pdf"
     pdf_path.write_bytes(pdf_bytes)
-    return gr.File.update(value=str(pdf_path), visible=True)
+    return gr.update(value=str(pdf_path), visible=True)
 
 
 with gr.Blocks(theme=gr.themes.Default(primary_hue="sky")) as ui:

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,13 @@ from dotenv import load_dotenv
 from pathlib import Path
 import tempfile
 import os
-from agent.stock_manager_agent import SupervisorManager
+import sys
+
+# When running this module directly, the repository root is not automatically
+# on ``sys.path``. Add it so that ``app`` can be imported as a package.
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app.agent.stock_manager_agent import SupervisorManager
 
 
 

--- a/app/stock/stock_data.py
+++ b/app/stock/stock_data.py
@@ -5,8 +5,8 @@ import requests
 from datetime import datetime, timedelta
 import warnings
 
-from stock.stock_symbol import quick_symbol_lookup
-from stock.stock_news import get_news
+from .stock_symbol import quick_symbol_lookup
+from .stock_news import get_news
 warnings.filterwarnings('ignore')
 
 class StockAnalyzer:

--- a/main.py
+++ b/main.py
@@ -1,10 +1,6 @@
-import gradio as gr
-from dotenv import load_dotenv
 from pathlib import Path
 import tempfile
-import os
-from agent.stock_manager_agent import SupervisorManager
-
+import gradio as gr
 
 
 def markdown_to_pdf_bytes(markdown_text: str) -> bytes:
@@ -51,42 +47,16 @@ def markdown_to_pdf_bytes(markdown_text: str) -> bytes:
     pdf_lines.append("%%EOF")
     return "\n".join(pdf_lines).encode("latin1", errors="replace")
 
-load_dotenv(override=True)
-username = os.getenv("GRADIO_USERNAME")
-password = os.getenv("GRADIO_PASSWORD")
 
-async def run(query: str):
-    manager = SupervisorManager()
-    last_chunk = ""
-    async for chunk in manager.run(query):
-        last_chunk = chunk
-        yield chunk, last_chunk
-
-
-def save_pdf(report_text: str):
-    pdf_bytes = markdown_to_pdf_bytes(report_text)
+def save_pdf(markdown_text: str) -> str:
+    pdf_bytes = markdown_to_pdf_bytes(markdown_text)
     temp_dir = Path(tempfile.gettempdir())
     pdf_path = temp_dir / "report.pdf"
     pdf_path.write_bytes(pdf_bytes)
-    return gr.File.update(value=str(pdf_path), visible=True)
+    return str(pdf_path)
 
 
-with gr.Blocks(theme=gr.themes.Default(primary_hue="sky")) as ui:
-    gr.Markdown("# AI Agent Stock Analysist ")
-    query_textbox = gr.Textbox(label="Analysis Apple stock")
-    run_button = gr.Button("Run", variant="primary")
-    report = gr.Markdown(label="Report")
-    download_button = gr.Button("Download PDF")
-    download_file = gr.File(label="PDF", visible=False)
-    state = gr.State("")
+if __name__ == "__main__":
+    import app.main as app_main
 
-    run_button.click(fn=run, inputs=query_textbox, outputs=[report, state])
-    query_textbox.submit(fn=run, inputs=query_textbox, outputs=[report, state])
-    download_button.click(fn=save_pdf, inputs=state, outputs=download_file)
-
-#ui.launch(inbrowser=True)
-ui.launch(
-    inbrowser=True,
-    auth=[(username, password)],  # or auth=[("user1", "pass1"), ("user2", "pass2")]
-    auth_message="Please log in to use the stock analysis tool"
-)
+    app_main.ui.launch()


### PR DESCRIPTION
## Summary
- fix imports across packages for reliable module loading
- expose a `markdown_to_pdf_bytes` helper and PDF-saving helper in new `main.py`
- add a PDF download button to the Gradio UI and handle PDF generation on demand

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868a90b42208327a66620cdb7858ee8