### PR TITLE
Add PDF download button

### DIFF
--- a/app/agent/stock_manager_agent.py
+++ b/app/agent/stock_manager_agent.py
@@ -1,9 +1,16 @@
-from agents import Agent, Runner, trace, gen_trace_id, TResponseInputItem, AgentOutputSchema
-from agent.technical_agent import technical_agent
-from agent.fundamental_agent import fundamental_agent
-from agent.investment_agent import investment_agent
-from agent.news_agent import news_agent
-from agent.stock_query_agent import query_agent
+from agents import (
+    Agent,
+    Runner,
+    trace,
+    gen_trace_id,
+    TResponseInputItem,
+    AgentOutputSchema,
+)
+from .technical_agent import technical_agent
+from .fundamental_agent import fundamental_agent
+from .investment_agent import investment_agent
+from .news_agent import news_agent
+from .stock_query_agent import query_agent
 
 REPORT_INSTRUCTION = """
             You need create tabular report based on the stock data of technical, fundamental, trend signal and stock news.

--- a/app/agent/stock_query_agent.py
+++ b/app/agent/stock_query_agent.py
@@ -1,7 +1,7 @@
 from agents import Agent, Runner, function_tool, AgentOutputSchema
 from pydantic import BaseModel
 from typing import Set, List, Dict, Tuple
-from stock.stock_data import StockAnalyzer, quick_symbol_lookup, get_news
+from ..stock.stock_data import StockAnalyzer, quick_symbol_lookup, get_news
 
 @function_tool
 def stock_analysis_tool(company_name: str, symbol: str = None) -> Dict[str, str]:

--- a/app/examples/stock_data_demo.py
+++ b/app/examples/stock_data_demo.py
@@ -1,4 +1,4 @@
-from stock.stock_data import main
+from ..stock.stock_data import main
 
 if __name__ == "__main__":
     main()

--- a/app/examples/stock_news_demo.py
+++ b/app/examples/stock_news_demo.py
@@ -1,4 +1,4 @@
-from stock.stock_news import main
+from ..stock.stock_news import main
 
 if __name__ == "__main__":
     main()

--- a/app/examples/stock_symbol_demo.py
+++ b/app/examples/stock_symbol_demo.py
@@ -1,4 +1,4 @@
-from stock.stock_symbol import main
+from ..stock.stock_symbol import main
 
 if __name__ == "__main__":
     main()

--- a/app/stock/stock_data.py
+++ b/app/stock/stock_data.py
@@ -5,8 +5,8 @@ import requests
 from datetime import datetime, timedelta
 import warnings
 
-from stock.stock_symbol import quick_symbol_lookup
-from stock.stock_news import get_news
+from .stock_symbol import quick_symbol_lookup
+from .stock_news import get_news
 warnings.filterwarnings('ignore')
 
 class StockAnalyzer:


### PR DESCRIPTION
## Summary
- fix imports across packages for reliable module loading
- expose a `markdown_to_pdf_bytes` helper and PDF-saving helper in new `main.py`
- add a PDF download button to the Gradio UI and handle PDF generation on demand
- ensure `app/main.py` works when executed directly
- fix file update call for Gradio download button

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868a90b42208327a66620cdb7858ee8